### PR TITLE
Allows scrolling comments when scrolling is disabled

### DIFF
--- a/base.user.js
+++ b/base.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Youtube short remover
 // @namespace    http://tampermonkey.net/
-// @version      base.1.3
+// @version      base.1.4
 // @description  Removes Youtube shorts from search results and watch page, but without a configuration menu.
 // @author       Mr_Comand
 // @license      MIT
@@ -82,7 +82,10 @@
         // Function to handle the custom scroll event
         function handleScroll(event) {
             if (youtubeShortPagePattern.test(window.location.href)) {
-
+                // If the event started inside the comments or an engagement panel, allow it.
+                if (event.target && event.target.closest && (event.target.closest('#comments') || event.target.closest('ytd-engagement-panel-section-list-renderer'))) {
+                    return;
+                }
                 // Your custom scroll handling code goes here
                 log("Scrolling is disabled.");
                 sendToHome();

--- a/merrged.user.js
+++ b/merrged.user.js
@@ -95,6 +95,11 @@
 	if (config.c_disableShortPageScrolling){
 		// Function to handle the custom scroll event
 		function handleScroll(event) {
+            // If the event started inside the comments or an engagement panel, allow it.
+            if (event.target && event.target.closest && (event.target.closest('#comments') || event.target.closest('ytd-engagement-panel-section-list-renderer'))) {
+                return;
+            }
+			
 			if (youtubeShortPagePattern.test(window.location.href)) {
 
 				// Your custom scroll handling code goes here

--- a/merrged.user.js
+++ b/merrged.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         Youtube short remover
 // @namespace    http://tampermonkey.net/
-// @version      full.1.3
+// @version      full.1.4
 // @description  Removes Youtube shorts from search results and watch page. Configuration Menu to the Settings at https://www.youtube.com/account_playback
 // @author       Mr_Comand
 // @license      MIT


### PR DESCRIPTION
Currently, "scrolling disabled" means you can't even scroll comments. This can be really annoying and unexpected. I've adjusted the script so that scrolling comments is allowed, but scrolling page is disabled (when it's disabled).

This is important, because if someone decides to watch a short, they are almost certainly okay with seeing other people's opinions on it, without being kicked off the short.